### PR TITLE
fix: update deprecated configparser names in versioneer.py

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -343,9 +343,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
## Description
- Fixes #5 
- Confirmed compatibility with Python 3.12
- Confirmed compatibility with Python 3.10


## To-dos
Notable points that this PR has either accomplished or will accomplish.
  - Update deprecated configparser names in versioneer.py

## Status
- Ready to go